### PR TITLE
Add USE_PRIVATE_CA env var to avoid create_ca_cert.sh script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 *.iml
 **/docker_mirror_cache
 **/docker_mirror_certs
+Makefile
+*.iid

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
 # syntax=docker/dockerfile:1
 # check=skip=SecretsUsedInArgOrEnv
 
+# -- File has been modified by YEXT  -- #
+
 # We start from my nginx fork which includes the proxy-connect module from tEngine
 # Source is available at https://github.com/rpardini/nginx-proxy-connect-stable-alpine
 # This is already multi-arch!
@@ -10,7 +12,7 @@ ARG BASE_IMAGE_SUFFIX=""
 FROM ${BASE_IMAGE}${BASE_IMAGE_SUFFIX}
 
 # Link image to original repository on GitHub
-LABEL org.opencontainers.image.source=https://github.com/rpardini/docker-registry-proxy
+LABEL org.opencontainers.image.source=https://github.com/yext/docker-registry-proxy
 
 # apk packages that will be present in the final image both debug and release
 RUN apk add --no-cache --update bash ca-certificates-bundle coreutils openssl

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+# File has been modified by YEXT #
 
 echo "Entrypoint starting."
 
@@ -57,9 +58,12 @@ for ONEREGISTRYIN in docker.caching.proxy.internal registry-1.docker.io auth.doc
     echo "${ONEREGISTRY} 127.0.0.1:443;" >> /etc/nginx/docker.intercept.map
 done
 
-# Clean the list and generate certificates.
-export ALLDOMAINS=${ALLDOMAINS:1} # remove the first comma and export
-/create_ca_cert.sh # This uses ALLDOMAINS to generate the certificates.
+USE_PRIVATE_CA=${USE_PRIVATE_CA:-false}
+if [[ "${USE_PRIVATE_CA}" == "false" ]]; then
+    # Clean the list and generate certificates.
+    export ALLDOMAINS=${ALLDOMAINS:1} # remove the first comma and export
+    /create_ca_cert.sh # This uses ALLDOMAINS to generate the certificates.
+fi
 
 # Target host interception. Empty by default. Used to intercept outgoing requests
 # from the proxy to the registries.


### PR DESCRIPTION
J=SYN-143
TEST=manual

Uploaded the image manually from machine to yext-docker-registry under the name rproxy