### PR TITLE
DockerRegistryProxy: Update invalid parameter for proxy_cache_path

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,7 @@ ENV SEND_TIMEOUT="60s" \
     PROXY_CONNECT_CONNECT_TIMEOUT="60s" \
     PROXY_CONNECT_SEND_TIMEOUT="60s"
 
-LABEL version="0.6.8" \
+LABEL version="0.6.9" \
 # Link image to original repository on GitHub
     org.opencontainers.image.source=https://github.com/yext/docker-registry-proxy
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 A caching proxy for Docker; allows centralised management of (multiple) registries and their authentication; caches images from *any* registry.
 Caches the potentially huge blob/layer requests (for bandwidth/time savings), and optionally caches manifest requests ("pulls") to avoid rate-limiting.
 
+### `0.6.9`: Update inactive value for proxy_cache_path to use env var
+
+inactive now sources its value from the `CACHE_VALID_TIME` environment variable
+
 ### `0.6.8`: Update dockerfile to run as nginx user instead of root
 
 docker-registry-proxy originally contained an nginx user however it did not set the container to run as nginx user. Updated the Dockerfile to set user as nginx and updated permissions + ports in nginx config to support this functionality.

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -111,12 +111,12 @@ CACHE_MAX_SIZE=${CACHE_MAX_SIZE:-32g}
 # Customizable cache directory via env vars
 CACHE_DIR=${CACHE_DIR:-/docker_mirror_cache}
 
-# The cache directory. This can get huge. Better to use a Docker volume pointing here!
-# Set to 32gb which should be enough
-echo "proxy_cache_path ${CACHE_DIR} levels=1:2 max_size=$CACHE_MAX_SIZE inactive=60d keys_zone=cache:10m use_temp_path=off;" > /etc/nginx/conf.d/cache_max_size.conf
-
 # Set Docker Registry cache valid time, by default, 60 day ('60d')
 CACHE_VALID_TIME=${CACHE_VALID_TIME:-60d}
+
+# The cache directory. This can get huge. Better to use a Docker volume pointing here!
+# Set to 32gb which should be enough
+echo "proxy_cache_path ${CACHE_DIR} levels=1:2 max_size=${CACHE_MAX_SIZE} inactive=${CACHE_VALID_TIME} keys_zone=cache:10m use_temp_path=off;" > /etc/nginx/conf.d/cache_max_size.conf
 
 # Set default cache valid time for 200 and 205 response.
 sed -i "/# Cache all 200, 206 for 60 days default./a\        proxy_cache_valid 200 206 ${CACHE_VALID_TIME};" /etc/nginx/nginx.conf


### PR DESCRIPTION
invalid parameter to source from env var CACHE_VALID_TIME

TEST=auto