### PR TITLE
DockerRegistryProxy: Add health endpoint to caching layer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,7 @@ ENV SEND_TIMEOUT="60s" \
     PROXY_CONNECT_CONNECT_TIMEOUT="60s" \
     PROXY_CONNECT_SEND_TIMEOUT="60s"
 
-LABEL version="0.6.9" \
+LABEL version="0.6.10" \
 # Link image to original repository on GitHub
     org.opencontainers.image.source=https://github.com/yext/docker-registry-proxy
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Caches the potentially huge blob/layer requests (for bandwidth/time savings), an
 
 ### `0.6.10`: Add health endpoint for https caching layer on port 8443
 
-You can now hit the caching layer health endpoint at `:8443/health`. This will return the health and ssl info.
+You can now hit the caching layer health endpoint at `:8443/healthz`. This will return the health and ssl info.
 
 ### `0.6.9`: Update inactive value for proxy_cache_path to use env var
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 A caching proxy for Docker; allows centralised management of (multiple) registries and their authentication; caches images from *any* registry.
 Caches the potentially huge blob/layer requests (for bandwidth/time savings), and optionally caches manifest requests ("pulls") to avoid rate-limiting.
 
+### `0.6.10`: Add health endpoint for https caching layer on port 8443
+
+You can now hit the caching layer health endpoint at `:8443/health`. This will return the health and ssl info.
+
 ### `0.6.9`: Update inactive value for proxy_cache_path to use env var
 
 inactive now sources its value from the `CACHE_VALID_TIME` environment variable

--- a/nginx.conf
+++ b/nginx.conf
@@ -265,6 +265,14 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             return 405 "docker-registry-proxy: docker is trying to use v1 API. Either the image does not exist upstream, or you need to configure docker-registry-proxy to authenticate against $host";
         }
 
+        # Health check endpoint for the caching layer.
+        # Returns a JSON object with status and SSL information.
+        location /health {
+            access_log off;
+            add_header "Content-Type" "application/json" always;
+            return 200 '{"status":"healthy","ssl_protocol":"$ssl_protocol","ssl_cipher":"$ssl_cipher","cert":"$ssl_server_name"}';
+        }
+
         # For blob requests by digest, do cache, and treat redirects.
         location ~ ^/v2/(.*)/blobs/sha256:(.*) {
             set $docker_proxy_request_type "blob-by-digest";

--- a/nginx.conf
+++ b/nginx.conf
@@ -267,7 +267,7 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
 
         # Health check endpoint for the caching layer.
         # Returns a JSON object with status and SSL information.
-        location /health {
+        location /healthz {
             access_log off;
             add_header "Content-Type" "application/json" always;
             return 200 '{"status":"healthy","ssl_protocol":"$ssl_protocol","ssl_cipher":"$ssl_cipher","cert":"$ssl_server_name"}';


### PR DESCRIPTION
Added /health endpoint on port 8443 to allow for curling the https endpoint for health status.

TEST=manual
J=SYN-246

Ran it locally and tested it. Pushed to image repo as well.