### PR TITLE
DockerRegistryProxy: Add redirect from /healthy to /healthz

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -154,7 +154,7 @@ ENV SEND_TIMEOUT="60s" \
     PROXY_CONNECT_CONNECT_TIMEOUT="60s" \
     PROXY_CONNECT_SEND_TIMEOUT="60s"
 
-LABEL version="0.6.10" \
+LABEL version="0.6.11" \
 # Link image to original repository on GitHub
     org.opencontainers.image.source=https://github.com/yext/docker-registry-proxy
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,10 @@
 A caching proxy for Docker; allows centralised management of (multiple) registries and their authentication; caches images from *any* registry.
 Caches the potentially huge blob/layer requests (for bandwidth/time savings), and optionally caches manifest requests ("pulls") to avoid rate-limiting.
 
+### `0.6.11`: Add extra /healthy endpoint that redirects to /healthz endpoint
+
+You can now hit the caching layer health endpoint at `:8443/healthy`. This will redirect to `/healthz`
+
 ### `0.6.10`: Add health endpoint for https caching layer on port 8443
 
 You can now hit the caching layer health endpoint at `:8443/healthz`. This will return the health and ssl info.

--- a/nginx.conf
+++ b/nginx.conf
@@ -273,6 +273,11 @@ echo "Docker configured with HTTPS_PROXY=$scheme://$http_host/"
             return 200 '{"status":"healthy","ssl_protocol":"$ssl_protocol","ssl_cipher":"$ssl_cipher","cert":"$ssl_server_name"}';
         }
 
+        # Redirect /healthy to /healthz for compatibility
+        location /healthy {
+            return 302 /healthz;
+        }
+
         # For blob requests by digest, do cache, and treat redirects.
         location ~ ^/v2/(.*)/blobs/sha256:(.*) {
             set $docker_proxy_request_type "blob-by-digest";


### PR DESCRIPTION
Yext convention is /healthy. To remove any cognitive load for troubleshooting we are adding an internal redirect to /healthz.

J=SYN-289
TEST=manual

Built and ran locally to test.